### PR TITLE
Update BR-DE-18 Line Feed handling.

### DIFF
--- a/validation/schematron/ubl-inv/UBL/XRechnung-UBL-model.sch
+++ b/validation/schematron/ubl-inv/UBL/XRechnung-UBL-model.sch
@@ -25,7 +25,7 @@
            satisfies matches (
                        normalize-space ($line),
                        $XR-SKONTO-REGEX
-                   ) and matches( cac:PaymentTerms/cbc:Note[1]/text(), '\n\s*$' )
+                   ) and matches( cac:PaymentTerms/cbc:Note[1]/text(), '[\n\s]*$' )
           " />
    
   <param name="BR-DE-19"


### PR DESCRIPTION
When using a single SKONTO line such as <cbc:Note>#SKONTO#TAGE=14#PROZENT=2.00#</cbc:Note>, the file fails validation because it is currently mandatory to have a line break.

Making the line break optional by changing this REGEX would both make this single line work as well as not make it mandatory to add a line feed on the end of the last line.